### PR TITLE
Update to include read-only check and resolve on css files

### DIFF
--- a/lessc.wsf
+++ b/lessc.wsf
@@ -171,6 +171,14 @@ Licensed under the Apache 2.0 License.
                         compress: args.compress
                     });
                     if (output) {
+                        if(fso.FileExists(output))
+     			    {
+					   var checkfile = fso.GetFile(output);
+					   if(checkfile.Attributes & 1)
+					   {
+					       checkfile.Attributes = checkfile.Attributes ^ 1
+					   }
+				    }
                         var outputfile = fso.CreateTextFile(output);
                         outputfile.Write(css);
                         outputfile.Close();


### PR DESCRIPTION
Update to include read-only check and resolve on files prior to trying to overwrite them. This is primarily for users of TFS who will encounter this issue and the associated error.
