### PR TITLE
Changing OpenTextFile to use ADODB.Stream to solve BOM issue

### DIFF
--- a/lessc.wsf
+++ b/lessc.wsf
@@ -16,26 +16,14 @@ Licensed under the Apache 2.0 License.
     var fso = new ActiveXObject("Scripting.FileSystemObject");
     var input = null;
 
-    var bomArr = [], bi;
-    bomArr[0] = String.fromCharCode(0xEF, 0xBB, 0xBF);
-    bomArr[1] = String.fromCharCode(0x10F, 0xBB, 0x17C); // reading Windows-1250 into utf
-
     var util = {
         readText: function (filename) {
-            //WScript.StdErr.WriteLine("readText: " + filename);
-            var file = fso.OpenTextFile(filename);
-            // Don't error on empty files
-            var text = file.AtEndOfStream ? '' : file.ReadAll();
-
-            // Strip off any UTF-8 BOM
-            for(bi = 0; bi < bomArr.length; bi++) {
-                utf8bom = bomArr[bi];
-                if (text.substr(0, utf8bom.length) == utf8bom) {
-                  text = text.substr(utf8bom.length);
-                  break;
-                }
-            }
-            file.Close();
+            var stream = WScript.CreateObject("ADODB.Stream"); // this should solve issue with OpenTextFile
+            stream.Charset = 'utf-8';
+            stream.Open();
+            stream.LoadFromFile(filename);
+            var text = stream.ReadText();
+            stream.close();
             return text;
         }
     };


### PR DESCRIPTION
not sure if this will work on all computers (ADOBE.Stream can be disabled as far as I know), but at least this makes checking for BOM unnecessary. It read properly file.

tried on files with ANSI, UTF-8 with BOM and UTF-8 without BOM encouraging.

sending this as pull request, maybe it would be helpful to solve issues that could be encountered on system with diff regional settings.
